### PR TITLE
fix(todo): Todo 생성 시 읽기 전용 트랜잭션 해제

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -25,6 +25,7 @@ public class TodoService {
     private final TodoRepository todoRepository;
     private final WeatherClient weatherClient;
 
+    @Transactional
     public TodoSaveResponse saveTodo(AuthUser authUser, TodoSaveRequest todoSaveRequest) {
         User user = User.fromAuthUser(authUser);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 작업 내용

- `TodoService.saveTodo()`에 `@Transactional`을 추가했습니다.
- 클래스 레벨의 `@Transactional(readOnly = true)` 설정으로 인해 Todo 생성 요청에서 DB insert가 read-only 커넥션으로 실행되던 문제를 수정했습니다.

## 문제 원인

`TodoService` 전체가 읽기 전용 트랜잭션으로 설정되어 있어, `POST /todos` 요청 시 `todoRepository.save()`가 실행될 때 아래 에러가 발생했습니다.

```text
Connection is read-only. Queries leading to data modification are not allowed
```

## 해결 방법

쓰기 작업인 `saveTodo()` 메서드에 별도의 `@Transactional`을 선언하여 클래스 레벨의 `readOnly = true` 설정을 override했습니다.
